### PR TITLE
Added Devcontainer Config

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,16 @@
+ARG VARIANT="noble"
+FROM buildpack-deps:${VARIANT}-curl
+
+# LABEL dev.containers.features="common"
+
+ARG VARIANT
+RUN if [ "$VARIANT" = "noble" ]; then \
+        if id "ubuntu" &>/dev/null; then \
+            echo "Deleting user 'ubuntu'  for $VARIANT" && userdel -f -r ubuntu || echo "Failed to delete ubuntu user for $VARIANT"; \  
+        else \
+            echo "User 'ubuntu' does not exist for $VARIANT"; \ 
+        fi; \
+    fi
+
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends git

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -2,35 +2,56 @@
 // README at: https://github.com/devcontainers/templates/tree/main/src/python
 {
     "name": "Oss4AI-dev",
-    // "image": "mcr.microsoft.com/devcontainers/python:1-3.12",
-	// "image": "ghcr.io/devcontainers/base:1",
-	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    "build": {
+        "dockerfile": "Dockerfile"
+    },
+
     	// Configure tool-specific properties.
 	"customizations": {
 		// Configure properties specific to VS Code.
 		"vscode": {
-			"settings": {},
+			"settings": {
+				"autoDocstring.docstringFormat": "google",
+                "terminal.integrated.shell.linux": "/bin/zsh"
+			},
 			"extensions": [
+				"codezombiech.gitignore",
+                "DavidAnson.vscode-markdownlint",
+                "donjayamanne.githistory",
+                "donjayamanne.python-environment-manager",
+                "donjayamanne.vscode-default-python-kernel",
+                "eamodio.gitlens",
+                "ionutvmi.path-autocomplete",
+                "marchiore.csvtomarkdown",
+                "mechatroner.rainbow-csv",
+                "ms-python.python",
+                "ms-toolsai.jupyter",
+                "ms-vsliveshare.vsliveshare",
+                "njpwerner.autodocstring",
                 "streetsidesoftware.code-spell-checker",
-                "ms-toolsai.jupyter"
             ]
 		}
 	},
 
-	// "containerEnv": {
-	// 	"PYTHONPATH": "/workspace"
-	// },
+    "forwardPorts": [6006],
 
     // Features to add to the dev container. More info: https://containers.dev/features.
 	"features": {
         "ghcr.io/va-h/devcontainers-features/uv:1": {},
-		"ghcr.io/schlich/devcontainer-features/powerlevel10k:1": {},
+		"ghcr.io/devcontainers/features/common-utils:2": {
+            "installZsh": true,
+            "configureZshAsDefaultShell": true,
+            "installOhMyZsh": true,
+            "username": "vscode",
+			"userUid": "1000",
+			"userGid": "1000"
+        },
 		"ghcr.io/devcontainers/features/python:1": {
             "version": "3.12.1",
-            "additionalVersions": "3.11.9",
             "installJupyterlab": "true",
             "configureJupyterlabAllowOrigin": "*",
             "useOryxIfAvailable": "false"
 		}
-    }
+    },
+    "remoteUser": "vscode"
 }

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,36 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the
+// README at: https://github.com/devcontainers/templates/tree/main/src/python
+{
+    "name": "Oss4AI-dev",
+    // "image": "mcr.microsoft.com/devcontainers/python:1-3.12",
+	// "image": "ghcr.io/devcontainers/base:1",
+	"image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+    	// Configure tool-specific properties.
+	"customizations": {
+		// Configure properties specific to VS Code.
+		"vscode": {
+			"settings": {},
+			"extensions": [
+                "streetsidesoftware.code-spell-checker",
+                "ms-toolsai.jupyter"
+            ]
+		}
+	},
+
+	// "containerEnv": {
+	// 	"PYTHONPATH": "/workspace"
+	// },
+
+    // Features to add to the dev container. More info: https://containers.dev/features.
+	"features": {
+        "ghcr.io/va-h/devcontainers-features/uv:1": {},
+		"ghcr.io/schlich/devcontainer-features/powerlevel10k:1": {},
+		"ghcr.io/devcontainers/features/python:1": {
+            "version": "3.12.1",
+            "additionalVersions": "3.11.9",
+            "installJupyterlab": "true",
+            "configureJupyterlabAllowOrigin": "*",
+            "useOryxIfAvailable": "false"
+		}
+    }
+}

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -1,0 +1,5 @@
+{
+    "recommendations": [
+        "ms-vscode-remote.remote-containers"
+    ]
+}

--- a/README.md
+++ b/README.md
@@ -8,14 +8,23 @@ What is an AI Agent? An AI that can use other software as tools.
 Prereqs:
 - Python 3.10 or higher
 
-## Devcontainer Setup
 
-Prerequisites: vscode, docker
+
+# Setup
 
 A **development container** is a running container with a well-defined tool/runtime stack and its prerequisites. You can try out development containers with **[GitHub Codespaces](https://github.com/features/codespaces)** or **[Visual Studio Code Dev Containers](https://aka.ms/vscode-remote/containers)**.
 
-1. Install the [vscode devcontainer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-2. Click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/UserNobody14/ai_agents_cookbooks) to automatically install and open the cookbooks in a new devcontainer
+### Devcontainer Setup
 
-## Codespaces Setup
+1. Install docker and visual studio code, if you haven't already
+2. Install the [vscode devcontainer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+3. Either click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/UserNobody14/ai_agents_cookbooks) to automatically install and open the cookbooks in a new devcontainer, *or* follow the proceeding steps if you want to put them in a more recognizable place.
 
+5. Clone this repository onto your local computer
+6. Open up the folder in vscode
+7. Press "Ctrl-Shift-P" in vscode, and type "Dev Containers: Rebuild and Reopen"
+8. You should be good!
+
+### Codespaces Setup
+
+1. Just navigate to this repo on github, and in the dropdown menu, select "Codespaces".

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Prerequisites: vscode, docker
 A **development container** is a running container with a well-defined tool/runtime stack and its prerequisites. You can try out development containers with **[GitHub Codespaces](https://github.com/features/codespaces)** or **[Visual Studio Code Dev Containers](https://aka.ms/vscode-remote/containers)**.
 
 1. Install the [vscode devcontainer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
-2. Click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/https://github.com/UserNobody14/ai_agents_cookbooks/devcontainer1) to automatically install and open the cookbooks in a new devcontainer
+2. Click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/UserNobody14/ai_agents_cookbooks) to automatically install and open the cookbooks in a new devcontainer
 
 ## Codespaces Setup
 

--- a/README.md
+++ b/README.md
@@ -7,3 +7,15 @@ What is an AI Agent? An AI that can use other software as tools.
 
 Prereqs:
 - Python 3.10 or higher
+
+## Devcontainer Setup
+
+Prerequisites: vscode, docker
+
+A **development container** is a running container with a well-defined tool/runtime stack and its prerequisites. You can try out development containers with **[GitHub Codespaces](https://github.com/features/codespaces)** or **[Visual Studio Code Dev Containers](https://aka.ms/vscode-remote/containers)**.
+
+1. Install the [vscode devcontainer extension](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers)
+2. Click [here](https://vscode.dev/redirect?url=vscode://ms-vscode-remote.remote-containers/cloneInVolume?url=https://github.com/https://github.com/UserNobody14/ai_agents_cookbooks/devcontainer1) to automatically install and open the cookbooks in a new devcontainer
+
+## Codespaces Setup
+

--- a/llamaindex/openai_rag_agent_w_evals.ipynb
+++ b/llamaindex/openai_rag_agent_w_evals.ipynb
@@ -13,8 +13,22 @@
    "cell_type": "code",
    "execution_count": 1,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Collecting uv\n",
+      "  Downloading uv-0.4.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl.metadata (11 kB)\n",
+      "Downloading uv-0.4.18-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl (12.9 MB)\n",
+      "\u001b[2K   \u001b[90m━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━\u001b[0m \u001b[32m12.9/12.9 MB\u001b[0m \u001b[31m30.7 MB/s\u001b[0m eta \u001b[36m0:00:00\u001b[0ma \u001b[36m0:00:01\u001b[0m\n",
+      "\u001b[?25hInstalling collected packages: uv\n",
+      "Successfully installed uv-0.4.18\n"
+     ]
+    }
+   ],
    "source": [
+    "!pip install uv\n",
     "!uv pip install --system -qU llama-index==0.11.6 llama-index-llms-openai llama-index-readers-file llama-index-embeddings-openai llama-index-llms-openai-like \"openinference-instrumentation-llama-index>=2\" arize-phoenix python-dotenv"
    ]
   },
@@ -80,14 +94,6 @@
    "execution_count": 4,
    "metadata": {},
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/local/python/3.12.1/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
-      "  from .autonotebook import tqdm as notebook_tqdm\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -172,18 +178,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Parsing nodes: 100%|██████████| 238/238 [00:00<00:00, 595.71it/s]\n",
-      "Generating embeddings: 100%|██████████| 343/343 [00:07<00:00, 46.29it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if not index_loaded:\n",
     "    # load data\n",
@@ -297,20 +294,20 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "> Running step 623d9dff-f0e4-42ae-9929-693275753ed7. Step input: Who had more profit in 2021, Lyft or Uber?\n",
-      "\u001b[1;3;38;5;200mThought: The current language of the user is English. I need to use the tools to help me answer the question. I will first use the lyft_10k tool to get the profit of Lyft in 2021, then I will use the uber_10k tool to get the profit of Uber in 2021.\n",
+      "> Running step 7f87b724-df99-463b-893a-82cb31b9470f. Step input: Who had more profit in 2021, Lyft or Uber?\n",
+      "\u001b[1;3;38;5;200mThought: To answer this question, I need to use the lyft_10k and uber_10k tools to get the financial information for both companies in 2021.\n",
       "Action: lyft_10k\n",
       "Action Input: {'input': \"What was Lyft's profit in 2021?\"}\n",
-      "\u001b[0m\u001b[1;3;34mObservation: Lyft did not make a profit in 2021. The company reported a net loss of $1,009,359,000 for the year.\n",
-      "\u001b[0m> Running step 62152001-73a4-429b-bbba-acbb65aa507e. Step input: None\n",
-      "\u001b[1;3;38;5;200mThought: Lyft reported a net loss in 2021. Now I need to find out Uber's profit for the same year to compare.\n",
+      "\u001b[0m\u001b[1;3;34mObservation: Lyft reported a net loss of $1,009,359,000 in 2021.\n",
+      "\u001b[0m> Running step 5963a567-7570-450d-899e-497fdc2c44d6. Step input: None\n",
+      "\u001b[1;3;38;5;200mThought: Now that I have the profit information for Lyft, I need to get the same information for Uber.\n",
       "Action: uber_10k\n",
       "Action Input: {'input': \"What was Uber's profit in 2021?\"}\n",
       "\u001b[0m\u001b[1;3;34mObservation: Uber reported a net loss of $496 million in 2021.\n",
-      "\u001b[0m> Running step 1b41268f-6828-449d-b1ba-65a00ef8176b. Step input: None\n",
-      "\u001b[1;3;38;5;200mThought: I can answer without using any more tools. Both companies reported a net loss in 2021, but Uber's loss was less than Lyft's. Therefore, Uber had a better financial performance in terms of profit.\n",
-      "Answer: Neither Lyft nor Uber made a profit in 2021. However, Uber's net loss was less than Lyft's, making Uber's financial performance better in terms of profit. Uber reported a net loss of $496 million, while Lyft reported a net loss of $1,009,359,000.\n",
-      "\u001b[0mNeither Lyft nor Uber made a profit in 2021. However, Uber's net loss was less than Lyft's, making Uber's financial performance better in terms of profit. Uber reported a net loss of $496 million, while Lyft reported a net loss of $1,009,359,000.\n"
+      "\u001b[0m> Running step 7f188c8d-04a4-430e-96b5-1606eb64cc7c. Step input: None\n",
+      "\u001b[1;3;38;5;200mThought: I can answer without using any more tools. I'll use the user's language to answer.\n",
+      "Answer: Both Lyft and Uber reported net losses in 2021. However, Uber had a smaller loss of $496 million compared to Lyft's loss of $1,009,359,000. Therefore, Uber was more profitable than Lyft in 2021.\n",
+      "\u001b[0mBoth Lyft and Uber reported net losses in 2021. However, Uber had a smaller loss of $496 million compared to Lyft's loss of $1,009,359,000. Therefore, Uber was more profitable than Lyft in 2021.\n"
      ]
     }
    ],

--- a/llamaindex/openai_rag_agent_w_evals.ipynb
+++ b/llamaindex/openai_rag_agent_w_evals.ipynb
@@ -28,7 +28,6 @@
     }
    ],
    "source": [
-    "!pip install uv\n",
     "!uv pip install --system -qU llama-index==0.11.6 llama-index-llms-openai llama-index-readers-file llama-index-embeddings-openai llama-index-llms-openai-like \"openinference-instrumentation-llama-index>=2\" arize-phoenix python-dotenv"
    ]
   },
@@ -178,9 +177,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsing nodes: 100%|██████████| 238/238 [00:00<00:00, 595.71it/s]\n",
+      "Generating embeddings: 100%|██████████| 343/343 [00:07<00:00, 46.29it/s]\n"
+     ]
+    }
+   ],
    "source": [
     "if not index_loaded:\n",
     "    # load data\n",

--- a/llamaindex/openai_rag_agent_w_evals.ipynb
+++ b/llamaindex/openai_rag_agent_w_evals.ipynb
@@ -11,11 +11,10 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {},
    "outputs": [],
    "source": [
-    "!pip install uv\n",
     "!uv pip install --system -qU llama-index==0.11.6 llama-index-llms-openai llama-index-readers-file llama-index-embeddings-openai llama-index-llms-openai-like \"openinference-instrumentation-llama-index>=2\" arize-phoenix python-dotenv"
    ]
   },
@@ -29,7 +28,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -50,7 +49,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -78,9 +77,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/local/python/3.12.1/lib/python3.12/site-packages/tqdm/auto.py:21: TqdmWarning: IProgress not found. Please update jupyter and ipywidgets. See https://ipywidgets.readthedocs.io/en/stable/user_install.html\n",
+      "  from .autonotebook import tqdm as notebook_tqdm\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🌍 To view the Phoenix app in your browser, visit http://localhost:6006/\n",
+      "📖 For more information on how to use Phoenix, check out https://docs.arize.com/phoenix\n"
+     ]
+    }
+   ],
    "source": [
     "import phoenix as px\n",
     "session = px.launch_app()"
@@ -88,9 +104,28 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "🔭 OpenTelemetry Tracing Details 🔭\n",
+      "|  Phoenix Project: default\n",
+      "|  Span Processor: SimpleSpanProcessor\n",
+      "|  Collector Endpoint: localhost:4317\n",
+      "|  Transport: gRPC\n",
+      "|  Transport Headers: {'user-agent': '****'}\n",
+      "|  \n",
+      "|  Using a default SpanProcessor. `add_span_processor` will overwrite this default.\n",
+      "|  \n",
+      "|  `register` has set this TracerProvider as the global OpenTelemetry default.\n",
+      "|  To disable this behavior, call `register` with `set_global_tracer_provider=False`.\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "from openinference.instrumentation.llama_index import LlamaIndexInstrumentor\n",
     "from phoenix.otel import register\n",
@@ -108,7 +143,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -137,9 +172,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "Parsing nodes: 100%|██████████| 238/238 [00:00<00:00, 595.71it/s]\n",
+      "Generating embeddings: 100%|██████████| 343/343 [00:07<00:00, 46.29it/s]\n"
+     ]
+    }
+   ],
    "source": [
     "if not index_loaded:\n",
     "    # load data\n",
@@ -168,7 +212,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -187,7 +231,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -225,7 +269,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 10,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -246,9 +290,30 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 11,
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "> Running step 623d9dff-f0e4-42ae-9929-693275753ed7. Step input: Who had more profit in 2021, Lyft or Uber?\n",
+      "\u001b[1;3;38;5;200mThought: The current language of the user is English. I need to use the tools to help me answer the question. I will first use the lyft_10k tool to get the profit of Lyft in 2021, then I will use the uber_10k tool to get the profit of Uber in 2021.\n",
+      "Action: lyft_10k\n",
+      "Action Input: {'input': \"What was Lyft's profit in 2021?\"}\n",
+      "\u001b[0m\u001b[1;3;34mObservation: Lyft did not make a profit in 2021. The company reported a net loss of $1,009,359,000 for the year.\n",
+      "\u001b[0m> Running step 62152001-73a4-429b-bbba-acbb65aa507e. Step input: None\n",
+      "\u001b[1;3;38;5;200mThought: Lyft reported a net loss in 2021. Now I need to find out Uber's profit for the same year to compare.\n",
+      "Action: uber_10k\n",
+      "Action Input: {'input': \"What was Uber's profit in 2021?\"}\n",
+      "\u001b[0m\u001b[1;3;34mObservation: Uber reported a net loss of $496 million in 2021.\n",
+      "\u001b[0m> Running step 1b41268f-6828-449d-b1ba-65a00ef8176b. Step input: None\n",
+      "\u001b[1;3;38;5;200mThought: I can answer without using any more tools. Both companies reported a net loss in 2021, but Uber's loss was less than Lyft's. Therefore, Uber had a better financial performance in terms of profit.\n",
+      "Answer: Neither Lyft nor Uber made a profit in 2021. However, Uber's net loss was less than Lyft's, making Uber's financial performance better in terms of profit. Uber reported a net loss of $496 million, while Lyft reported a net loss of $1,009,359,000.\n",
+      "\u001b[0mNeither Lyft nor Uber made a profit in 2021. However, Uber's net loss was less than Lyft's, making Uber's financial performance better in terms of profit. Uber reported a net loss of $496 million, while Lyft reported a net loss of $1,009,359,000.\n"
+     ]
+    }
+   ],
    "source": [
     "response = agent.chat(\"Who had more profit in 2021, Lyft or Uber?\")\n",
     "print(str(response))"
@@ -257,7 +322,7 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "aacb",
+   "display_name": "Python 3",
    "language": "python",
    "name": "python3"
   },
@@ -271,7 +336,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.9"
+   "version": "3.12.1"
   }
  },
  "nbformat": 4,

--- a/llamaindex/openai_rag_agent_w_evals.ipynb
+++ b/llamaindex/openai_rag_agent_w_evals.ipynb
@@ -28,6 +28,7 @@
     }
    ],
    "source": [
+    "!pip install uv\n",
     "!uv pip install --system -qU llama-index==0.11.6 llama-index-llms-openai llama-index-readers-file llama-index-embeddings-openai llama-index-llms-openai-like \"openinference-instrumentation-llama-index>=2\" arize-phoenix python-dotenv"
    ]
   },
@@ -177,18 +178,9 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "Parsing nodes: 100%|██████████| 238/238 [00:00<00:00, 595.71it/s]\n",
-      "Generating embeddings: 100%|██████████| 343/343 [00:07<00:00, 46.29it/s]\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "if not index_loaded:\n",
     "    # load data\n",


### PR DESCRIPTION
Hey! This is Ben, from the hackathons.

In many of the events there seems to be a bit of a struggle for everyone to get on the same page vis-a-vis python versions and dependencies and such, so I thought it might be a good idea to put everything into a vscode devcontainer. I've been working with devcontainers for a while at work, they're really neat! Basically vscode opens up a docker image and installs some tools, then adds whatever you're working on into the container as a volume. The advantage is, all the versions/extensions/etc will be the same, and all the tools/env will be too! It even prevents dependency hell, since it isolates different python projects!

I set it up in this repo for python with my windows laptop, and confirmed it works perfectly on mac as well. I didn't test out the older milvus/zilliz stuff, but all of the more recent notebooks run fine, including the arize ones, and I forwarded port 6006 so that the arize server would be visible in the browser.

Devcontainers are also useful for github codespaces iirc, although i don't have as much experience there.

It does take a while for it to get initialized when first run, although its lightning fast after that! Also requires that people have docker, but the "manual" setup is still open in this case! Since these additions don't require any changes in the notebooks I figured I'd make a PR in case you wanted it!